### PR TITLE
Fixed Makevars added RcppArmadillo.h import

### DIFF
--- a/src/Cluster.cpp
+++ b/src/Cluster.cpp
@@ -1,4 +1,5 @@
 #include "Cluster.hpp"
+#include <RcppArmadillo.h>
 #include <cmath>
 
 Cluster::Cluster(int _count, arma::rowvec & _mean, arma::mat & _covMat):

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,13 +1,16 @@
 ## -*- mode: makefile; -*-
 
-R_HOME := 		$(shell R RHOME)
-RCPPFLAGS := 		$(shell $(R_HOME)/bin/R CMD config --cppflags)
-RLDFLAGS := 		$(shell $(R_HOME)/bin/R CMD config --ldflags)
-RCPPINCL := 		$(shell echo 'Rcpp:::CxxFlags()' | $(R_HOME)/bin/R --vanilla --slave)
-RCPPLIBS := 		$(shell echo 'Rcpp:::LdFlags()'  | $(R_HOME)/bin/R --vanilla --slave)	
+R_HOME := $(shell R RHOME)
+RCPPFLAGS := $(shell $(R_HOME)/bin/R CMD config --cppflags)
+RLDFLAGS := $(shell $(R_HOME)/bin/R CMD config --ldflags)
+RCPPINCL := $(shell echo 'Rcpp:::CxxFlags()' | $(R_HOME)/bin/R --vanilla --slave)
+RCPPLIBS := $(shell echo 'Rcpp:::LdFlags()' | $(R_HOME)/bin/R --vanilla --slave)
+RCPPARMAINCL := $(shell echo 'RcppArmadillo:::CxxFlags()' | $(R_HOME)/bin/R --vanilla --slave)
+LAPACK_LIBS := $(shell ${R_HOME}/bin/R CMD config LAPACK_LIBS)
+BLAS_LIBS := $(shell ${R_HOME}/bin/R CMD config BLAS_LIBS)
 
-CXX := 			$(shell $(R_HOME)/bin/R CMD config CXX)
-CPPFLAGS := 		-Wall $(shell $(R_HOME)/bin/R CMD config CPPFLAGS)
-CXXFLAGS := 		$(RCPPFLAGS) $(RCPPINCL) $(shell $(R_HOME)/bin/R CMD config CXXFLAGS) -pthread -fpic
-LDLIBS := 		$(RLDFLAGS) $(RCPPLIBS) -larmadillo
-PKG_LIBS := 		$(LDLIBS)
+
+
+PKG_CPPFLAGS := -I../inst/include -I. $(shell $(R_HOME)/bin/R CMD config CPPFLAGS)
+PKG_CXXFLAGS := $(RCPPFLAGS) $(RCPPINCL) $(RCPPARMAINCL) $(RINSIDEINCL) $(shell $(R_HOME)/bin/R CMD config CXXFLAGS) -g -pthread -fpic
+PKG_LIBS := $(RLDFLAGS) $(RRPATH) $(RBLAS) $(RLAPACK) $(RCPPLIBS) $(RINSIDELIBS) -lboost_thread -lrt -lpthread $(LAPACK_LIBS) $(BLAS_LIBS) -larmadillo

--- a/test/cpp/Makefile
+++ b/test/cpp/Makefile
@@ -4,8 +4,9 @@ else
 
 include src/Makevars
 CXX := $(CXX) -isystem $(GTEST)/include
-CXXFLAGS := -g -O2 -s -pthread
-LDLIBS := -larmadillo
+CPPFLAGS := $(PKG_CPPFLAGS)
+CXXFLAGS := $(PKG_CXXFLAGS) -g -O2 -s -pthread
+LDLIBS := $(PKG_LIBS) $(LDLIBS) -larmadillo
 USER_DIR = ../../src
 
 TESTS = ClusterTest firstTest onlineTest ellipse_gauss_test simple_1_test mouse_1_test


### PR DESCRIPTION
Tests are building and passing. I have fixed arma::fill bug - compilation required external armadillo which was unacceptable. Notes:
- I have added RcppArmadillo.h in random place - you can move it
- My changes in Makefile in tests/ are also a little bit messy

I have noticed btw few things. One is: remove firstTest.cc ;)
